### PR TITLE
Change Mission Upload Text

### DIFF
--- a/app/Http/Controllers/MissionsuploadController.php
+++ b/app/Http/Controllers/MissionsuploadController.php
@@ -46,11 +46,8 @@ class MissionsuploadController extends Controller
                 'mission.max' => 'Die Datei darf maximal 20 MB groß sein!',
             ]
         );
-        if ($request->has('missionfinal') === false) {
-            return redirect()->route('missionupload.index')->withErrors('So geht das nicht! Du musst schon sagen, ob das eine spielbereite Mission ist oder nicht!');
-        }
-        if ($request->get('missionfinal') == 1 and $request->get('tests') != "1") {
-            return redirect()->route('missionupload.index')->withErrors('Das ist eine spielbereite Mission und du hast keine Alpha- und Beta-Tests gemacht? Na so geht das aber nicht! Deine Mission kommt in den Papierkorb und machst brav deine Tests. Dann kannst du gerne wieder kommen.');
+        if ($request->get('uploadcheck') != "1") {
+            return redirect()->route('missionupload.index')->withErrors('Bitte bestätige, dass dir bewusst ist das die Mission von jedem auf dem Server gestartet werden kann.');
         }
         if ($request->hasFile('mission')) {
             //get filename with extension

--- a/resources/views/intern/missionupload/upload.blade.php
+++ b/resources/views/intern/missionupload/upload.blade.php
@@ -18,17 +18,9 @@
         <br>
         <form action="{{route("missionsupload.store")}}" method="post" enctype="multipart/form-data">
             @csrf
-            <label for="missionfinal">Ist dies eine fertige Mission, die bereit zum Spielen ist?</label>
-
-            <select name="missionfinal" id="missionfinal">
-                <option value="0" disabled selected>--- Bitte auswählen</option>
-                <option value="1">Ja</option>
-                <option value="2">Nein</option>
-                <option value="3" disabled>Ich habe keine Ahnung -> In diesem Fall die Missionbau-Hinweise durchlesen!</option>
-            </select>
-            <div id="missiontester" style="display: none">
-                <input type="checkbox" id="tests" name="tests" value="1">
-                <label for="tests">Ich habe sowohl einen Alpha- als auch einen Beta-Test durchgeführt und mich dabei an alle Missionsbau-Hinweise gehalten.</label>
+            <div id="missionuploadcheck">
+                <input type="checkbox" id="uploadcheck" name="uploadcheck" value="1">
+                <label for="uploadcheck">Mir ist bewusst, dass eine auf den Server hochgeladene Mission von jedem gestartet werden kann.</label>
             </div>
             <hr>
             <input type="file" name="mission" accept=".pbo">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -454,16 +454,6 @@
             },
             "order": [[2, 'desc']]
         });
-        $('#missionfinal').on('change', function () {
-            value = this.value;
-            if (value == 1) {
-                $("#missiontester").show();
-                $("#tests").prop('required', true);
-            } else {
-                $("#missiontester").hide();
-                $("#tests").prop('required', false);
-            }
-        });
 
         if (tpj("#rev_slider_24_1").revolution == undefined) {
             revslider_showDoubleJqueryError("#rev_slider_24_1");


### PR DESCRIPTION
Ändert den Text für den Missions Upload. 

Die Checkliste wird gelöscht. 
Funktion welche ein Bestätigungsfeld anzeigt/nicht anzeigt ob Tests gemacht wurden wurde entfernt

Checkbox wurde umbenannt und Text angepasst. Checkbox ist dauerhaft sichtbar,